### PR TITLE
[D-13736]: Forcechange flag to edit a user via CLI is not working correctly

### DIFF
--- a/ctmcommands/admin/createuser.py
+++ b/ctmcommands/admin/createuser.py
@@ -41,7 +41,7 @@ class CreateUser(ctmcommands.cmd.CSKCommand):
                Param(name='forcechange', short_name='f', long_name='forcechange',
                      optional=True, ptype='integer',
                      doc='Require user to change password. Default is "true" (1) if omitted. (Valid values: 0 or 1).',
-                     choices=[0, 1]),
+                     choices=[0, 1], default=1),
                Param(name='status', short_name='s', long_name='status',
                      optional=True, ptype='string',
                      doc='Status of the new account. Default is "enabled" if omitted. (Valid values: enabled, disabled, locked)',

--- a/ctmcommands/admin/updateuser.py
+++ b/ctmcommands/admin/updateuser.py
@@ -44,7 +44,7 @@ class UpdateUser(ctmcommands.cmd.CSKCommand):
                Param(name='forcechange', short_name='f', long_name='forcechange',
                      optional=True, ptype='integer',
                      doc='Require user to change password. Default is "true" (1) if omitted. (Valid values: 0 or 1).',
-                     choices=[0, 1]),
+                     choices=[0, 1], default=1),
                Param(name='status', short_name='s', long_name='status',
                      optional=True, ptype='string',
                      doc='Status of the new account. Default is "enabled" if omitted. (Valid values: enabled, disabled, locked)',

--- a/ctmcommands/cmd.py
+++ b/ctmcommands/cmd.py
@@ -399,7 +399,7 @@ class CSKCommand(object):
         args = data
         argstr = ""
         for param in parameters:
-            if getattr(self, param, None):
+            if getattr(self, param, None) is not None:
                 args[param] = getattr(self, param)
 
         # if post then args are a dict, if get args are qs


### PR DESCRIPTION

1. Set default value for force change as 1.
2. Changed the condition in getattr to check None instead of just checking if the param has value in it.

The reason why i changed to None is when an integer value is checked and if the integer has a value 0 for the param, the if evaluates false
and the the param is not even considered while executing the CLI