### PR TITLE
[S-73789] echo-only api docs

### DIFF
--- a/bin/ctm-list-commands
+++ b/bin/ctm-list-commands
@@ -11,7 +11,10 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         # if there's an argument, simply switch on it.  It'll only be asking for the api or dumpdoc.
         if sys.argv[1] == "--dumpdoc" or sys.argv[1] == "-H":
-            print """Lists all installed Continuum commands.  Accepts no arguments."""
+            if sys.argv[1] == "--dumpdoc":
+                print('<h3 id="{0}" title="Permalink">{0}&nbsp;<a href="#{0}" style="display: margin-left: 1em;">&para;</a></h3>\n'.format('ctm-list-commands'))
+
+            print """Lists all installed ctm-* commands.  Accepts no arguments."""
             exit()
         else:
             exit()

--- a/ctmcommands/admin/installlicense.py
+++ b/ctmcommands/admin/installlicense.py
@@ -12,7 +12,7 @@ from builtins import input
 
 class InstallLicense(ctmcommands.cmd.CSKCommand):
 
-    Description = 'Installs or updates the Continuum license by importing a license file'
+    Description = 'Installs or updates the Agility Connect/Continuum license by importing a license file'
     API = 'install_license'
     Examples = '''
     ctm-install-license -i "~/license.lic"

--- a/ctmcommands/admin/listmethods.py
+++ b/ctmcommands/admin/listmethods.py
@@ -15,11 +15,11 @@ class ListMethods(ctmcommands.cmd.CSKCommand):
     Examples = '''
 _To print a full listing of all api commands with documentation_
 
-    ctm-list-methods
+    ctm-describe-api
 
 _To print only the names with the api commands sorted_
 
-    ctm-list-methods -l
+    ctm-describe-api -l
 '''
     Options = [Param(name='listonly', short_name='l', long_name='listonly',
                      optional=True, ptype='boolean',

--- a/ctmcommands/admin/testmsghub.py
+++ b/ctmcommands/admin/testmsghub.py
@@ -21,7 +21,7 @@ _To send an email to an email address_
 '''
     Options = [Param(name='server', short_name='s', long_name='server',
                      optional=False, ptype='string',
-                     doc='URL of the Continuum server.  Use "wss" if Continuum is running in SSL mode, otherwise use "ws".  Use the port as configured, or the default of 8083.')
+                     doc='URL of the Agile Connect/Continuum server.  Use "wss" if server is running in SSL mode, otherwise use "ws".  Use the port as configured, or the default of 8083.')
                ]
 
     def main(self):


### PR DESCRIPTION
* bin/ctm-list-commands
  Implement --dumpdoc

* ctmcommands/admin/installlicense.py
* ctmcommands/admin/testmsghub.py
  Use 'Agility Connect/Continuum' in description

* ctmcommands/admin/listmethods.py
  command name was previously changed to 'ctm-describe-api'